### PR TITLE
Do not read role_name for approle token

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -31,19 +31,17 @@
         name: ensure-output-dirs
       when: ansible_user_dir is defined
 
-# If job has zuul_vault variable with role_name use it to generate wrapped
-# secret-id and leave it at well-known location. The job is then responsible to
-# take it and use. Secret is wrapped with ttl set to job timeout
+# If there is a registered role (as constructed from project name) try to
+# generate secret-id and leave it at well-known location. The job is then
+# responsible to take it and use. Secret is wrapped with ttl set to job timeout
 - hosts: localhost
   roles:
     - role: create-vault-approle-secret
       vault_addr: "{{ zuul_vault_addr }}"
       vault_token: "{{ lookup('file', zuul_base_vault_token_path) }}"
       vault_secret_dest: "{{ zuul.executor.work_root }}/.approle-secret"
-      vault_role_name: "{{ zuul_vault.vault_role_name }}"
+      vault_role_name: "{{ ['zuul', zuul.tenant, zuul.project.name] | join('_') | regexp_replace('/', '_') }}"
       when:
         - "zuul.post_review | bool"
         - "zuul_vault_addr is defined"
         - "zuul_base_vault_token_path is defined"
-        - "zuul_vault is defined"
-        - "zuul_vault.vault_role_name is defined"


### PR DESCRIPTION
Instead of reading role_name from job use project name. This let us
ensure only allowed projects are coming here.
