### PR TITLE
Init src compression for the pod case

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -21,6 +21,8 @@
     - block:
         # A Pod way
         - include_role:
+            name: prepare-workspace-k8
+        - include_role:
             name: prepare-workspace-openshift
         - include_role:
             name: remove-zuul-sshkey

--- a/roles/prepare-workspace-k8/README.rst
+++ b/roles/prepare-workspace-k8/README.rst
@@ -1,0 +1,16 @@
+Prepare remote workspaces in Kubernetes
+
+This role can be used instead of the :zuul:role:`prepare-workspace`
+role when the synchronize module doesn't work with kubectl connection.
+It copies the prepared source repos to the pods' cwd using the `oc
+rsync` command.
+
+This role is intended to run once before any other role in a Zuul job.
+This role requires the origin-clients to be installed.
+
+**Role Variables**
+
+.. zuul:rolevar:: openshift_pods
+   :default: {{ zuul.resources }}
+
+   The dictionary of pod name, pod information to copy the sources to.

--- a/roles/prepare-workspace-k8/defaults/main.yaml
+++ b/roles/prepare-workspace-k8/defaults/main.yaml
@@ -1,0 +1,1 @@
+openshift_pods: "{{ zuul.resources }}"

--- a/roles/prepare-workspace-k8/tasks/main.yaml
+++ b/roles/prepare-workspace-k8/tasks/main.yaml
@@ -1,0 +1,6 @@
+---
+- include_tasks: rsync.yaml
+  when: zj_pod.1.pod is defined
+  loop: "{{ openshift_pods.items()|list }}"
+  loop_control:
+    loop_var: zj_pod

--- a/roles/prepare-workspace-k8/tasks/rsync.yaml
+++ b/roles/prepare-workspace-k8/tasks/rsync.yaml
@@ -1,0 +1,23 @@
+---
+- name: Archive sources
+  archive:
+    path: "{{ zuul.executor.src_root }}"
+    dest: "{{ zuul.executor.work_root }}/archive.tgz"
+  delegate_to: localhost
+
+- name: Create src directory
+  command: >
+    oc --context "{{ zj_pod.1.context }}"
+       --namespace "{{ zj_pod.1.namespace }}"
+       exec {{ zj_pod.1.pod }} mkdir src
+  delegate_to: localhost
+
+- name: Copy src repos to the pod
+  command: >
+    oc --context "{{ zj_pod.1.context }}"
+       --namespace "{{ zj_pod.1.namespace }}"
+        rsync -q --progress=false
+          {{ zuul.executor.work_root }}/archive.tgz
+          {{ zj_pod.1.pod }}:src/archive.tgz
+  no_log: true
+  delegate_to: localhost


### PR DESCRIPTION
When test job is running in the pod transfering big repository might
take lot of time. Instead try to transfer sources as archive. For this
first add new role that compresses sources and passes it to the
destination without uncompressing.
